### PR TITLE
clarify README

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@ First, clone this repository:
   git clone https://github.com/aartaka/nx-dark-reader.git ~/.local/share/nyxt/extensions/nx-dark-reader
 #+end_src
 
-Then load it in your init file and add it to your =default-modes=:
+Then load it in your init file:
 
 #+begin_src lisp
   ;;; ~/.config/nyxt/config.lisp
@@ -20,7 +20,7 @@ Then load it in your init file and add it to your =default-modes=:
     :depends-on (:nx-dark-reader) :components ("dark-reader.lisp"))
 #+end_src
 
-Optionally, configure it in the =dark-reader.lisp= (create if necessary).
+Optionally, configure it and add it to your =default-modes= in =dark-reader.lisp= (create the file if necessary).
 
 #+begin_src lisp
   ;;; ~/.config/nyxt/dark-reader.lisp
@@ -30,7 +30,7 @@ Optionally, configure it in the =dark-reader.lisp= (create if necessary).
      (nxdr:contrast 60)
      (nxdr:text-color "white")))
 
-
+  ;; Add dark-reader to default modes
   (define-configuration web-buffer
     ((default-modes `(nxdr:dark-reader-mode ,@%slot-value%))))
 #+end_src


### PR DESCRIPTION
The last command is the one that adds dark-reader to default-modes.

Prior to this commit, the Readme gives the impression that `(define-nyxt-user-system-and-load ... )` is the command that adds Dark Reader to `default-modes`.